### PR TITLE
Allow specification of ECR registry region

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -62,6 +62,10 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
     login_args+=("--no-include-email")
   fi
 
+  if [[ -n "${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION:-}" ]] ; then
+    login_args+=("--region" "${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION}")
+  fi
+
   if [[ ${#registry_ids[@]} -gt 0 ]] ; then
     login_args+=("--registry-ids" "${registry_ids[@]}")
   fi

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -90,3 +90,23 @@ load '/usr/local/lib/bats/load.bash'
 
   unstub aws
 }
+
+@test "Login to ECR with region specified" {
+  export BUILDKITE_PLUGIN_ECR_LOGIN=true
+  export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
+  export BUILDKITE_PLUGIN_ECR_REGISTRY_REGION=ap-southeast-2
+  
+  stub aws \
+    "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234.dkr.ecr.ap-southeast-2.amazonaws.com"
+
+  stub docker \
+    "login -u AWS -p 1234 https://1234.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker"
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "logging in to docker"
+
+  unstub aws
+  unstub docker
+}


### PR DESCRIPTION
We have a situation where our Buildkite agents run in and access other AWS resources from a different region to the container registry they need to pull from. This is resulting in the ECR plugin logging in to the wrong region, and hence failing to authenticate. 

This change creates an optional `BUILDKITE_PLUGIN_ECR_REGISTRY_REGION` (name open to negotiation 😄 ) environment variable to explicitly specify which region the registry you are trying to access is in. i.e., setting `BUILDKITE_PLUGIN_ECR_REGISTRY_REGION=us-east-1` lets us pull from the Virginia region even if `AWS_(DEFAULT_)REGION=ap-southeast-2`.