### PR TITLE
Update readme with latest version of plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This will login docker to ECR prior to running your script.
 steps:
   - command: ./run_build.sh
     plugins:
-      ecr#v1.0.0:
+      ecr#v1.1.2:
         login: true
 ```
 


### PR DESCRIPTION
I was trying to use the `no-include-email` flag, but it wasn't working. Took me a while to realise that's because I copied the version out of the readme. 