### PR TITLE
Add a retry with backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Add `--no-include-email` to ecr get-login. Required for docker 17.06+, but needs
 
 Set a specific region for ECR, defaults to the current
 
+### `retries` (optional)
+
+Retries login after a delay N times. Defaults to 0.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -42,15 +42,21 @@ function aws_version_ge() {
 
 # Retries a command on failure.
 function retry() {
-  local -r -i max_attempts="$1"; shift
+  local -r -i retries="$1"; shift
+  local -i max_attempts=$((retries + 1))
   local -i attempt_num=1
+  local exit_code
 
   until "$@" ; do
-    if (( attempt_num == max_attempts )) ; then
-      echo "Attempt $attempt_num failed and there are no more attempts left!" >&2
-      return 1
+    exit_code=$?
+    echo "$attempt_num == $retries" >&2
+    if [[ $retries -eq 0 ]] ; then
+      return $exit_code
+    elif (( attempt_num == max_attempts )) ; then
+      echo "Login failed after $attempt_num attempts" >&2
+      return $exit_code
     else
-      echo "Attempt $attempt_num failed! Trying again in $attempt_num seconds..." >&2
+      echo "Login failed on attempt ${attempt_num} of ${max_attempts}. Trying again in $attempt_num seconds..." >&2
       sleep $(( attempt_num++ ))
     fi
   done
@@ -90,7 +96,7 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
   fi
 
   # shellcheck disable=SC2068
-  ecr_login=$(retry "${BUILDKITE_PLUGIN_ECR_RETRY:-5}" aws ecr get-login ${login_args[@]+"${login_args[@]}"}) || exit $?
+  ecr_login=$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws ecr get-login ${login_args[@]+"${login_args[@]}"}) || exit $?
 
   echo "$ecr_login"
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -35,9 +35,25 @@ function aws_version_ge() {
   [[ ${current[1]} -gt ${wanted[1]} ]] && return 0
   [[ ${current[2]} -ge ${wanted[2]} ]] && return 0
 
-  echo "$version isn't ge $1"
+  echo "$version isn't ge $1" >&2
 
   return 1
+}
+
+# Retries a command on failure.
+function retry() {
+  local -r -i max_attempts="$1"; shift
+  local -i attempt_num=1
+
+  until "$@" ; do
+    if (( attempt_num == max_attempts )) ; then
+      echo "Attempt $attempt_num failed and there are no more attempts left!" >&2
+      return 1
+    else
+      echo "Attempt $attempt_num failed! Trying again in $attempt_num seconds..." >&2
+      sleep $(( attempt_num++ ))
+    fi
+  done
 }
 
 if [[ -z "${AWS_DEFAULT_REGION:-}" ]] ; then
@@ -74,7 +90,9 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
   fi
 
   # shellcheck disable=SC2068
-  ecr_login=$(aws ecr get-login ${login_args[@]+"${login_args[@]}"}) || exit $?
+  ecr_login=$(retry "${BUILDKITE_PLUGIN_ECR_RETRY:-5}" aws ecr get-login ${login_args[@]+"${login_args[@]}"}) || exit $?
+
+  echo "$ecr_login"
 
   # despite all the horror above, if we have docker > 17.06 it still breaks...
   eval "$(sed 's/-e none//' <<< "$ecr_login")"


### PR DESCRIPTION
In high concurrency setups ECR logins will often be rate limited. This adds a few retries with incrementing sleep in between them. 

Closes #7.
  