### PR TITLE
Allow AWS credentials to be passed in via config

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -99,12 +99,12 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
     echo "~~~ Authenticating with AWS ECR"
   fi
 
-  if [[ -z "${BUILDKITE_PLUGIN_ECR_ACCESS_KEY_ID:-}" ]] ; then
-    AWS_ACCESS_KEY_ID="$BUILDKITE_PLUGIN_ECR_ACCESS_KEY_ID"
+  if [[ -n "${BUILDKITE_PLUGIN_ECR_ACCESS_KEY_ID:-}" ]] ; then
+    export AWS_ACCESS_KEY_ID="$BUILDKITE_PLUGIN_ECR_ACCESS_KEY_ID"
   fi
 
-  if [[ -z "${BUILDKITE_PLUGIN_ECR_SECRET_ACCESS_KEY_ENV:-}" ]] ; then
-    AWS_SECRET_ACCESS_KEY="${!BUILDKITE_PLUGIN_ECR_SECRET_ACCESS_KEY_ENV}"
+  if [[ -n "${BUILDKITE_PLUGIN_ECR_SECRET_ACCESS_KEY_ENV:-}" ]] ; then
+    export AWS_SECRET_ACCESS_KEY="${!BUILDKITE_PLUGIN_ECR_SECRET_ACCESS_KEY_ENV}"
   fi
 
   # shellcheck disable=SC2068

--- a/hooks/environment
+++ b/hooks/environment
@@ -99,6 +99,14 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
     echo "~~~ Authenticating with AWS ECR"
   fi
 
+  if [[ -z "${BUILDKITE_PLUGIN_ECR_ACCESS_KEY_ID:-}" ]] ; then
+    AWS_ACCESS_KEY_ID="$BUILDKITE_PLUGIN_ECR_ACCESS_KEY_ID"
+  fi
+
+  if [[ -z "${BUILDKITE_PLUGIN_ECR_SECRET_ACCESS_KEY_ENV:-}" ]] ; then
+    AWS_SECRET_ACCESS_KEY="${!BUILDKITE_PLUGIN_ECR_SECRET_ACCESS_KEY_ENV}"
+  fi
+
   # shellcheck disable=SC2068
   ecr_login=$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws ecr get-login ${login_args[@]+"${login_args[@]}"}) || exit $?
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,5 +18,9 @@ configuration:
       type: boolean
     region:
       type: string
+    access-key-id:
+      type: string
+    secret-access-key-env:
+      type: string
   required:
     - login


### PR DESCRIPTION
This PR is more of a "is this even a thing we wanna do" type change. No dramas if it's totally wrong, happy to drop it and do it another way.

I have this snippet of YAML:

```
aws_auth:
  aws_access_key_id: $AWS_ACCESS_KEY_ID
  aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
```

I need to login to ECR using those credentials. From my understanding, if `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are present, it'll use those values (and ignore any instance creds or things on the file system) https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

My goal is to allow something like this:

```
steps:
  - command: ./run_build.sh
    plugins:
      - ecr#v2.0.0:
          login: true
          access_key_id: 1234
          secret_access_key_env: $ECR_PASSWORD
```

Am I barking up the wrong tree? Is this sorta thing legit?