### PR TITLE
Fix hook name in tests

### DIFF
--- a/tests/run.bats
+++ b/tests/run.bats
@@ -178,7 +178,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "login -u AWS -p supersecret https://1234.dkr.ecr.us-east-1.amazonaws.com : echo logging in to docker"
 
-  run $PWD/hooks/pre-command
+  run $PWD/hooks/environment
 
   assert_success
   refute_output --partial "supersecret"


### PR DESCRIPTION
This fixes the hook name change that we forgot to port into #29 before merging