### PR TITLE
shellcheck fixes

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -23,8 +23,8 @@ function plugin_read_list() {
 # Check a provided aws-cli version is greater or equal than the current
 function aws_version_ge() {
   local version; version="$(aws --version 2>&1 | awk -F'[/ ]' '{print $2}')"
-  local wanted=( ${1//./ } )
-  local current=( ${version//./ } )
+  IFS="." read -r -a wanted <<< "$1"
+  IFS="." read -r -a current <<< "$version"
 
   if [[ ! ${#current[@]} -eq 3 ]] ; then
     echo "Expected $version to be in the form x.y.z" >&2
@@ -76,7 +76,7 @@ fi
 
 # For logging into the current AWS account’s registry
 if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
-  registry_ids=( $(plugin_read_list ACCOUNT_IDS | tr "," "\n") )
+  mapfile -t registry_ids <<< "$(plugin_read_list ACCOUNT_IDS | tr "," "\n")"
   login_args=()
 
   if [[ $BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL =~ (true|on|1) ]] ; then
@@ -103,5 +103,7 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
   ecr_login=$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws ecr get-login ${login_args[@]+"${login_args[@]}"}) || exit $?
 
   # despite all the horror above, if we have docker > 17.06 it still breaks...
-  eval "$(sed 's/-e none//' <<< "$ecr_login")"
+  ecr_login="${ecr_login//-e none/}"
+
+  eval "$ecr_login"
 fi

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1,4 +1,6 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+# (modifying vars in subshells is expected)
 
 load '/usr/local/lib/bats/load.bash'
 
@@ -14,7 +16,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "login -u AWS -p 1234 https://1234.dkr.ecr.us-east-1.amazonaws.com : echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "logging in to docker"
@@ -33,7 +35,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "login -u AWS -p 1234 https://1234.dkr.ecr.us-east-1.amazonaws.com : echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "logging in to docker"
@@ -51,7 +53,7 @@ load '/usr/local/lib/bats/load.bash'
   stub aws \
     "ecr get-login --no-include-email --registry-ids 1111 2222 : echo echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "logging in to docker"
@@ -67,7 +69,7 @@ load '/usr/local/lib/bats/load.bash'
     "--version : echo aws-cli/1.11.40 Python/2.7.10 Darwin/16.6.0 botocore/1.5.80" \
     "ecr get-login --registry-ids 1111 2222 3333 : echo echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "logging in to docker"
@@ -83,7 +85,7 @@ load '/usr/local/lib/bats/load.bash'
     "--version : echo aws-cli/1.11.117 Python/2.7.10 Darwin/16.6.0 botocore/1.5.80" \
     "ecr get-login --no-include-email --registry-ids 1111 2222 3333 : echo echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "logging in to docker"
@@ -102,7 +104,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "login -u AWS -p 1234 https://1234.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "logging in to docker"
@@ -123,7 +125,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "login -u AWS -p 1234 https://1234.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "logging in to docker"
@@ -141,7 +143,7 @@ load '/usr/local/lib/bats/load.bash'
     "ecr get-login --no-include-email : exit 1" \
     "ecr get-login --no-include-email : echo echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   assert_output --partial "Login failed on attempt 1 of 2. Trying again in 1 seconds.."
@@ -159,7 +161,7 @@ load '/usr/local/lib/bats/load.bash'
     "ecr get-login --no-include-email : exit 1" \
     "ecr get-login --no-include-email : exit 1"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_failure
   assert_output --partial "Login failed on attempt 1 of 2. Trying again in 1 seconds..."
@@ -178,7 +180,7 @@ load '/usr/local/lib/bats/load.bash'
   stub docker \
     "login -u AWS -p supersecret https://1234.dkr.ecr.us-east-1.amazonaws.com : echo logging in to docker"
 
-  run $PWD/hooks/environment
+  run "$PWD/hooks/environment"
 
   assert_success
   refute_output --partial "supersecret"


### PR DESCRIPTION
[shellcheck](https://github.com/koalaman/shellcheck) flagged the following in hooks/environment:

```
In hooks/environment line 26:
  local wanted=( ${1//./ } )
                 ^-------^ SC2206: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In hooks/environment line 27:
  local current=( ${version//./ } )
                  ^-------------^ SC2206: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In hooks/environment line 79:
  registry_ids=( $(plugin_read_list ACCOUNT_IDS | tr "," "\n") )
                 ^-- SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).


In hooks/environment line 106:
  eval "$(sed 's/-e none//' <<< "$ecr_login")"
          ^-- SC2001: See if you can use ${variable//search/replace} instead.

For more information:
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
  https://www.shellcheck.net/wiki/SC2207 -- Prefer mapfile or read -a to spli...
  https://www.shellcheck.net/wiki/SC2001 -- See if you can use ${variable//se...
```

It also had things to say about the test BATS file, but that was less interesting.

This PR applies shellcheck's advice. I am doing this now so I can make some upcoming changes for #37 with clean shellcheck confidence.