### PR TITLE
AWS CLI Verison 2 support

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -69,12 +69,10 @@ function retry() {
   done
 }
 
-if [[ -z "${AWS_DEFAULT_REGION:-}" ]] ; then
-  export AWS_DEFAULT_REGION=us-east-1
-fi
-
-# For logging into the current AWS account’s registry
-if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
+# 'aws ecr get-login' was removed in awscli 2.0.0, but the alternative
+# 'aws ecr get-login-password' was not available until v1.7.10 which
+# was only released earlier that same month.
+function login_using_aws_ecr_get_login() {
   mapfile -t registry_ids <<< "$(plugin_read_list ACCOUNT_IDS | tr "," "\n")"
   login_args=()
 
@@ -114,4 +112,29 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
   ecr_login="${ecr_login//-e none/}"
 
   eval "$ecr_login"
+}
+
+function login_using_aws_ecr_get_login_password() {
+  # TODO: implement using aws ecr get-login-password; the current approach will
+  # not work with awscli v2.0.0 and above.
+  login_using_aws_ecr_get_login
+}
+
+function login() {
+  if aws_version_ge "1.17.10"; then
+    # 'aws ecr get-login-password' was added in awscli 1.17.10
+    login_using_aws_ecr_get_login_password
+  else
+    # older awscli versions must use 'aws ecr get-login'
+    login_using_aws_ecr_get_login
+  fi
+}
+
+if [[ -z "${AWS_DEFAULT_REGION:-}" ]] ; then
+  export AWS_DEFAULT_REGION="us-east-1"
+fi
+
+# For logging into the current AWS account’s registry
+if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
+  login
 fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -115,9 +115,23 @@ function login_using_aws_ecr_get_login() {
 }
 
 function login_using_aws_ecr_get_login_password() {
-  # TODO: implement using aws ecr get-login-password; the current approach will
-  # not work with awscli v2.0.0 and above.
-  login_using_aws_ecr_get_login
+  local region="${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION:-${BUILDKITE_PLUGIN_ECR_REGION:-${AWS_DEFAULT_REGION}}}"
+  if [[ -z $region ]]; then
+    echo >&2 "AWS region must be specified via plugin config or AWS_DEFAULT_REGION environment"
+    exit 1
+  fi
+  mapfile -t account_ids <<< "$(plugin_read_list ACCOUNT_IDS | tr "," "\n")"
+  if [[ -z ${account_ids[*]} ]]; then
+    account_ids=("$(aws sts get-caller-identity --query Account --output text)")
+  fi
+  if [[ -z ${account_ids[*]} ]]; then
+    echo >&2 "AWS account ID required via plugin config or 'aws sts get-caller-identity'"
+    exit 1
+  fi
+  local password; password="$(aws ecr get-login-password)"
+  for account_id in "${account_ids[@]}"; do
+    docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
+  done
 }
 
 function login() {

--- a/hooks/environment
+++ b/hooks/environment
@@ -89,6 +89,10 @@ function login_using_aws_ecr_get_login() {
     login_args+=("--no-include-email")
   fi
 
+  if [[ -z "${AWS_DEFAULT_REGION:-}" ]] ; then
+    export AWS_DEFAULT_REGION="us-east-1"
+  fi
+
   # In earlier versions, we supported registry-region. This is now deprecated
   if [[ -n "${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION:-}" ]] ; then
     login_args+=("--region" "${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION}")
@@ -115,10 +119,11 @@ function login_using_aws_ecr_get_login() {
 }
 
 function login_using_aws_ecr_get_login_password() {
-  local region="${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION:-${BUILDKITE_PLUGIN_ECR_REGION:-${AWS_DEFAULT_REGION}}}"
+  local region="${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION:-${BUILDKITE_PLUGIN_ECR_REGION:-${AWS_DEFAULT_REGION:-}}}"
   if [[ -z $region ]]; then
-    echo >&2 "AWS region must be specified via plugin config or AWS_DEFAULT_REGION environment"
-    exit 1
+    region="us-east-1"
+    echo >&2 "AWS region should be specified via plugin config or AWS_DEFAULT_REGION environment."
+    echo >&2 "Defaulting to $region for legacy compatibility."
   fi
   mapfile -t account_ids <<< "$(plugin_read_list ACCOUNT_IDS | tr "," "\n")"
   if [[ -z ${account_ids[*]} ]]; then
@@ -128,7 +133,7 @@ function login_using_aws_ecr_get_login_password() {
     echo >&2 "AWS account ID required via plugin config or 'aws sts get-caller-identity'"
     exit 1
   fi
-  local password; password="$(aws ecr get-login-password)"
+  local password; password="$(aws --region "$region" ecr get-login-password)"
   for account_id in "${account_ids[@]}"; do
     docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
   done
@@ -143,10 +148,6 @@ function login() {
     login_using_aws_ecr_get_login
   fi
 }
-
-if [[ -z "${AWS_DEFAULT_REGION:-}" ]] ; then
-  export AWS_DEFAULT_REGION="us-east-1"
-fi
 
 # For logging into the current AWS account’s registry
 if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -9,14 +9,14 @@ load '/usr/local/lib/bats/load.bash'
 @test "ECR login; configured account ID, configured region" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=321321321321
-  export BUILDKITE_PLUGIN_ECR_REGION=ap-southeast-1
+  export BUILDKITE_PLUGIN_ECR_REGION=ap-southeast-2
 
   stub aws \
     "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
-    "ecr get-login-password : echo hunter2"
+    "--region ap-southeast-2 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 321321321321.dkr.ecr.ap-southeast-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin 321321321321.dkr.ecr.ap-southeast-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -31,14 +31,14 @@ load '/usr/local/lib/bats/load.bash'
 @test "ECR login; configured account ID, configured legacy registry-region" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=321321321321
-  export BUILDKITE_PLUGIN_ECR_REGISTRY_REGION=ap-southeast-1
+  export BUILDKITE_PLUGIN_ECR_REGISTRY_REGION=ap-southeast-2
 
   stub aws \
     "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
-    "ecr get-login-password : echo hunter2"
+    "--region ap-southeast-2 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 321321321321.dkr.ecr.ap-southeast-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin 321321321321.dkr.ecr.ap-southeast-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -49,14 +49,14 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
   unstub docker
 }
-@test "ECR login; configured account ID, discovered region" {
+@test "ECR login; configured account ID, AWS_DEFAULT_REGION set" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=421321321321
   export AWS_DEFAULT_REGION=us-west-2
 
   stub aws \
     "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
-    "ecr get-login-password : echo hunter2"
+    "--region us-west-2 ecr get-login-password : echo hunter2"
 
   stub docker \
     "login --username AWS --password-stdin 421321321321.dkr.ecr.us-west-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
@@ -70,22 +70,24 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
   unstub docker
 }
-@test "ECR login; configured account ID, default region" {
+@test "ECR login; configured account ID, no region specified defaults to us-east-1" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=421321321321
 
   stub aws \
     "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
-    "ecr get-login-password : echo hunter2"
+    "--region us-east-1 ecr get-login-password : echo hunter2"
 
   stub docker \
     "login --username AWS --password-stdin 421321321321.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
+
   run "$PWD/hooks/environment"
 
   assert_success
+  assert_output --partial "AWS region should be specified"
+  assert_output --partial "Defaulting to us-east-1"
   assert_output --partial "logging in to docker"
-  [[ $(cat /tmp/password-stdin) == "hunter2" ]]
 
   unstub aws
   unstub docker
@@ -94,10 +96,11 @@ load '/usr/local/lib/bats/load.bash'
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0=111111111111
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_1=222222222222
+  export BUILDKITE_PLUGIN_ECR_REGION=us-east-1
 
   stub aws \
     "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
-    "ecr get-login-password : echo sameforeachaccount"
+    "--region us-east-1 ecr get-login-password : echo sameforeachaccount"
 
   stub docker \
     "login --username AWS --password-stdin 111111111111.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-0 ; echo logging in to docker" \
@@ -117,10 +120,11 @@ load '/usr/local/lib/bats/load.bash'
 @test "ECR login; multiple comma-separated account IDs" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=333333333333,444444444444
+  export BUILDKITE_PLUGIN_ECR_REGION=us-east-1
 
   stub aws \
     "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
-    "ecr get-login-password : echo sameforeachaccount"
+    "--region us-east-1 ecr get-login-password : echo sameforeachaccount"
 
   stub docker \
     "login --username AWS --password-stdin 333333333333.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-0 ; echo logging in to docker" \
@@ -139,11 +143,12 @@ load '/usr/local/lib/bats/load.bash'
 }
 @test "ECR login; discovered account ID" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
+  export AWS_DEFAULT_REGION=us-east-1
 
   stub aws \
     "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "sts get-caller-identity --query Account --output text : echo 888888888888" \
-    "ecr get-login-password : echo hunter2"
+    "--region us-east-1 ecr get-login-password : echo hunter2"
 
   stub docker \
     "login --username AWS --password-stdin 888888888888.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -6,11 +6,30 @@ load '/usr/local/lib/bats/load.bash'
 
 # export AWS_STUB_DEBUG=/dev/tty
 
-@test "Login to ECR" {
+@test "ECR login (v2.0.0; after get-login was removed)" {
+  skip "awscli v2+ not yet supported"
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
 
   stub aws \
+    "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
+    "ecr get-login --no-include-email : echo fail && false"
+
+  run "$PWD/hooks/environment"
+
+  assert_success
+  assert_output --partial "logging in to docker"
+
+  unstub aws
+  unstub docker
+}
+
+@test "ECR login (v1.17.10; after get-login-password was added, before get-login was removed)" {
+  export BUILDKITE_PLUGIN_ECR_LOGIN=true
+  export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
+
+  stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234.dkr.ecr.us-east-1.amazonaws.com"
 
   stub docker \
@@ -25,11 +44,32 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Login to ECR (without --no-include-email)" {
+@test "aws ecr get-login (v1.17.9; before get-login-password was added)" {
+  export BUILDKITE_PLUGIN_ECR_LOGIN=true
+  export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
+
+  stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
+    "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234.dkr.ecr.us-east-1.amazonaws.com"
+
+  stub docker \
+    "login -u AWS -p 1234 https://1234.dkr.ecr.us-east-1.amazonaws.com : echo logging in to docker"
+
+  run "$PWD/hooks/environment"
+
+  assert_success
+  assert_output --partial "logging in to docker"
+
+  unstub aws
+  unstub docker
+}
+
+@test "aws ecr get-login (without --no-include-email)" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=false
 
   stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login : echo docker login -u AWS -p 1234 https://1234.dkr.ecr.us-east-1.amazonaws.com"
 
   stub docker \
@@ -44,13 +84,14 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Login to ECR with Account IDS" {
+@test "aws ecr get-login with Account IDS" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0=1111
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_1=2222
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
 
   stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login --no-include-email --registry-ids 1111 2222 : echo echo logging in to docker"
 
   run "$PWD/hooks/environment"
@@ -61,11 +102,12 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
-@test "Login to ECR with Comma-delimited Account IDS (older aws-cli)" {
+@test "aws ecr get-login with Comma-delimited Account IDS (older aws-cli)" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS="1111,2222,3333"
 
   stub aws \
+    "--version : echo aws-cli/1.11.40 Python/2.7.10 Darwin/16.6.0 botocore/1.5.80" \
     "--version : echo aws-cli/1.11.40 Python/2.7.10 Darwin/16.6.0 botocore/1.5.80" \
     "ecr get-login --registry-ids 1111 2222 3333 : echo echo logging in to docker"
 
@@ -77,11 +119,12 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
-@test "Login to ECR with Comma-delimited Account IDS (newer aws-cli)" {
+@test "aws ecr get-login with Comma-delimited Account IDS (newer aws-cli)" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS="1111,2222,3333"
 
   stub aws \
+    "--version : echo aws-cli/1.11.117 Python/2.7.10 Darwin/16.6.0 botocore/1.5.80" \
     "--version : echo aws-cli/1.11.117 Python/2.7.10 Darwin/16.6.0 botocore/1.5.80" \
     "ecr get-login --no-include-email --registry-ids 1111 2222 3333 : echo echo logging in to docker"
 
@@ -93,12 +136,13 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
-@test "Login to ECR with region specified" {
+@test "aws ecr get-login with region specified" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
   export BUILDKITE_PLUGIN_ECR_REGISTRY_REGION=ap-southeast-2
 
   stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login --no-include-email --region ap-southeast-2 : echo docker login -u AWS -p 1234 https://1234.dkr.ecr.ap-southeast-2.amazonaws.com"
 
   stub docker \
@@ -113,13 +157,14 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Login to ECR with region and registry id's" {
+@test "aws ecr get-login with region and registry id's" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS="1111,2222,3333"
   export BUILDKITE_PLUGIN_ECR_REGISTRY_REGION=ap-southeast-2
 
   stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login --no-include-email --region ap-southeast-2 --registry-ids 1111 2222 3333 : echo docker login -u AWS -p 1234 https://1234.dkr.ecr.ap-southeast-2.amazonaws.com"
 
   stub docker \
@@ -134,12 +179,14 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Login to ECR with error, and then retry until success" {
+@test "aws ecr get-login with error, and then retry until success" {
+  [[ -z $SKIP_SLOW ]] || skip "skipping slow test"
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
   export BUILDKITE_PLUGIN_ECR_RETRIES=1
 
   stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login --no-include-email : exit 1" \
     "ecr get-login --no-include-email : echo echo logging in to docker"
 
@@ -152,12 +199,14 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
-@test "Login to ECR with error, and then retry until failure" {
+@test "aws ecr get-login with error, and then retry until failure" {
+  [[ -z $SKIP_SLOW ]] || skip "skipping slow test"
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
   export BUILDKITE_PLUGIN_ECR_RETRIES=1
 
   stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login --no-include-email : exit 1" \
     "ecr get-login --no-include-email : exit 1"
 
@@ -170,11 +219,12 @@ load '/usr/local/lib/bats/load.bash'
   unstub aws
 }
 
-@test "Login to ECR doesn't disclose credentials" {
+@test "aws ecr get-login doesn't disclose credentials" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_NO_INCLUDE_EMAIL=true
 
   stub aws \
+    "--version : echo aws-cli/1.17.9 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
     "ecr get-login --no-include-email : echo docker login -u AWS -p supersecret https://1234.dkr.ecr.us-east-1.amazonaws.com"
 
   stub docker \


### PR DESCRIPTION
- [x] _rebase away the temporary merge of #39, once it's in master_ 

[awscli v2.0.0 removed](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst#200) the [`aws ecr get-login` command](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html), in favour of the [`aws ecr get-login-password` command](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html) which was [introduced very recently in v1.17.10](https://github.com/aws/aws-cli/pull/5026) via https://github.com/aws/aws-cli/pull/4874 . In order for ecr-buildkite-plugin to support new and slightly-less-new versions of the AWS CLI, we need to decide which to use by version-checking.

Additionally, the new `get-login-password` no longer provides the ECR registry address(es), so we need to build them with knowledge of the AWS account ID and region.

AWS region is determined by:

* (legacy `registry-region` plugin config)
* `region` plugin config
* `AWS_DEFAULT_REGION` environment
* `us-east-1` default.

AWS account IDs are determined by:

* `account-ids` plugin config (YAML array, or legacy comma-separated)
* `aws sts get-caller-identity`

If multiple `account-ids` are configured, a single `aws ecr get-login-password` call is made, and multiple `docker login ...` are made; one for each account/registry. This is correct according to https://github.com/aws/aws-cli/pull/4874#issuecomment-582644940 and https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth:

> The password that is returned is valid for any registry that your IAM principal has access to. We have updated our documentation to be more explicit about the authorization data that is returned in the `get-authorization-token` and `get-login-password` commands.

Fixes #37