### PR TITLE
bash 3.x compatibility; avoid mapfile

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -73,7 +73,11 @@ function retry() {
 # 'aws ecr get-login-password' was not available until v1.7.10 which
 # was only released earlier that same month.
 function login_using_aws_ecr_get_login() {
-  mapfile -t registry_ids <<< "$(plugin_read_list ACCOUNT_IDS | tr "," "\n")"
+  # bash 3.x compatible equivalent of mapfile;
+  # https://github.com/koalaman/shellcheck/wiki/SC2207
+  registry_ids=()
+  while IFS='' read -r line; do registry_ids+=("$line"); done < <(plugin_read_list ACCOUNT_IDS | tr "," "\n")
+
   login_args=()
 
   # If not specified, auto-detect if we can support no-include-email
@@ -125,7 +129,8 @@ function login_using_aws_ecr_get_login_password() {
     echo >&2 "AWS region should be specified via plugin config or AWS_DEFAULT_REGION environment."
     echo >&2 "Defaulting to $region for legacy compatibility."
   fi
-  mapfile -t account_ids <<< "$(plugin_read_list ACCOUNT_IDS | tr "," "\n")"
+  account_ids=()
+  while IFS='' read -r line; do account_ids+=("$line"); done < <(plugin_read_list ACCOUNT_IDS | tr "," "\n")
   if [[ -z ${account_ids[*]} ]]; then
     account_ids=("$(aws sts get-caller-identity --query Account --output text)")
   fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -131,10 +131,10 @@ function login_using_aws_ecr_get_login_password() {
   fi
   account_ids=()
   while IFS='' read -r line; do account_ids+=("$line"); done < <(plugin_read_list ACCOUNT_IDS | tr "," "\n")
-  if [[ -z ${account_ids[*]} ]]; then
+  if [[ ${#account_ids[@]} -eq 0 ]]; then
     account_ids=("$(aws sts get-caller-identity --query Account --output text)")
   fi
-  if [[ -z ${account_ids[*]} ]]; then
+  if [[ ${#account_ids[@]} -eq 0 ]]; then
     echo >&2 "AWS account ID required via plugin config or 'aws sts get-caller-identity'"
     exit 1
   fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -131,10 +131,12 @@ function login_using_aws_ecr_get_login_password() {
   fi
   account_ids=()
   while IFS='' read -r line; do account_ids+=("$line"); done < <(plugin_read_list ACCOUNT_IDS | tr "," "\n")
-  if [[ ${#account_ids[@]} -eq 0 ]]; then
+  # check if account_ids is empty, or only contains an empty string.
+  # just testing [[ -z ${account_ids[*]} ]] breaks on bash 3.x if the array is empty.
+  if [[ ${#account_ids[@]} -eq 0 || -z "${account_ids[*]}" ]]; then
     account_ids=("$(aws sts get-caller-identity --query Account --output text)")
   fi
-  if [[ ${#account_ids[@]} -eq 0 ]]; then
+  if [[ ${#account_ids[@]} -eq 0 || -z "${account_ids[*]}" ]]; then
     echo >&2 "AWS account ID required via plugin config or 'aws sts get-caller-identity'"
     exit 1
   fi


### PR DESCRIPTION
Use of `mapfile` was introduced in da2472ff784ab6ed427f9827d79bb10ac11c0060 (to fix a `shellcheck`) and 509678c036900a38e9a47cbcc56e567d987b087d (to support awscli v2). `mapfile` was introduced in bash 4.x, but there are many systems that ship with bash 3.x (perhaps just macOS, but there's a lot of macOS systems 😅).

This patch takes advice from shellcheck at https://github.com/koalaman/shellcheck/wiki/SC2207 to use bash 3.x compatible `read -a` to remove the dependency on `mapfile` while also avoiding the previous `shellcheck` warnings.

Fixes #46, closes #47.

Ping: @pdbreen @ryansdwilson @kkolk