### PR TITLE
Regretfully delete acceptance test; no AWS access in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,12 +14,3 @@ steps:
       shellcheck#v1.0.1:
         files: hooks/**
     skip: "Shellcheck doesn't pass right now"
-
-  - wait
-
-  - label: check login happens correctly
-    command: grep 032379705303 ~/.docker/config.json
-    plugins:
-      ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}:
-        login: "true"
-        account-ids: "032379705303"


### PR DESCRIPTION
CI pipeline has been moved to agents without any AWS access, to make building third-party contributions safer. So we can't test actually using the plugin to authenticate against ECR.