### PR TITLE
Fix allow other accounts link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ steps:
           login: true
 ```
 
-If you want to log in to ECR on [another account](https://docs.aws.amazon.com/AmazonECR/latest/userguide/RepositoryPolicyExamples.html#IAM_allow_other_accounts):
+If you want to log in to ECR on [another account](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html#IAM_allow_other_accounts):
 
 
 ```yml


### PR DESCRIPTION
AWS did not have redirect for this URL change so 🤷🏻‍♀️