### PR TITLE
Support assume role before ECR login

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ steps:
 
 If you want to log in to ECR on [another account](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policy-examples.html#IAM_allow_other_accounts):
 
+```yml
+steps:
+  - command: ./run_build.sh
+    plugins:
+      - ecr#v2.1.1:
+          login: true
+          account_ids: "0015615400570"
+          region: "ap-southeast-2"
+```
+
+If you need to assume a role to perform that login:
 
 ```yml
 steps:
@@ -27,6 +38,8 @@ steps:
           login: true
           account_ids: "0015615400570"
           region: "ap-southeast-2"
+          assume_role:
+            role_arn: "arn:aws:iam::0015615400570:role/demo"
 ```
 
 ## Options
@@ -50,6 +63,10 @@ Set a specific region for ECR, defaults to `AWS_DEFAULT_REGION` on the agent, or
 ### `retries` (optional)
 
 Retries login after a delay N times. Defaults to 0.
+
+### `assume-role` (optional)
+
+Assume an AWS IAM role before ECR login. Supports `role-arn` and `duration-seconds` (optional) per the [associated AWS CLI command.](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/assume-role.html)
 
 ## License
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -157,19 +157,24 @@ function login() {
 }
 
 function assume_role_for_ecr_login() {
-  export "$(aws sts assume-role \
+  local export_credentials; export_credentials="$(aws sts assume-role \
     --role-arn "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_ROLE_ARN}" \
     --role-session-name "ecr-login-buildkite-plugin" \
     --duration-seconds "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_DURATION_SECONDS:-3600}" \
     --output text \
     --query "[['AWS_ACCESS_KEY_ID',Credentials.AccessKeyId],['AWS_SECRET_ACCESS_KEY',Credentials.SecretAccessKey],['AWS_SESSION_TOKEN',Credentials.SessionToken]][*].join(\`=\`,@)")"
+
+  #shellcheck disable=SC2086
+  export ${export_credentials?}
 }
 
 # For logging into the current AWS account’s registry
 if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
-  if [[ -n "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_ROLE_ARN:-}" ]]; then
-    assume_role_for_ecr_login
-  fi
+  (
+    if [[ -n "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_ROLE_ARN:-}" ]]; then
+      assume_role_for_ecr_login
+    fi
 
-  login
+    login
+  )
 fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -156,7 +156,20 @@ function login() {
   fi
 }
 
+function assume_role_for_ecr_login() {
+  export "$(aws sts assume-role \
+    --role-arn "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_ROLE_ARN}" \
+    --role-session-name "ecr-login-buildkite-plugin" \
+    --duration-seconds "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_DURATION_SECONDS:-3600}" \
+    --output text \
+    --query "[['AWS_ACCESS_KEY_ID',Credentials.AccessKeyId],['AWS_SECRET_ACCESS_KEY',Credentials.SecretAccessKey],['AWS_SESSION_TOKEN',Credentials.SessionToken]][*].join(\`=\`,@)")"
+}
+
 # For logging into the current AWS account’s registry
 if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
+  if [[ -n "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_ROLE_ARN:-}" ]]; then
+    assume_role_for_ecr_login
+  fi
+
   login
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -18,5 +18,13 @@ configuration:
       type: boolean
     region:
       type: string
+    assume-role:
+      type: object
+      properties:
+        role-arn:
+          type: string
+        duration-seconds:
+          type: number
+          default: 3600
   required:
     - login


### PR DESCRIPTION
If I want to log in to two ECRs, in different accounts, which both require an assumed role, I have to perform the following dance:

```yaml
steps:
  - plugins:
      - cultureamp/aws-assume-role#v0.2.0:
          role: "arn:aws:iam::$AWS_ACCOUNT_1_ID:role/$AWS_ROLE_1"
      - ecr#v1.2.0: # can't use 2.0+ because of hook order
          login: true
          account_ids: "$AWS_ACCOUNT_1_ID"
      - cultureamp/aws-assume-role#v0.2.0:
          role: "arn:aws:iam::$AWS_ACCOUNT_2_ID:role/$AWS_ROLE_2"
      - ecr#v1.2.0:
          login: true
          account_ids: "$AWS_ACCOUNT_2_ID"
```

Note:
- Given that it's an environment hook, I can't replace the `aws-assume-role` plugin calls with scripts in the repo, either.
- Changing the `cultureamp/aws-assume-role` plugin to act on the `environment` hook would prevent build steps from assuming different roles for different parts of a step. I assume that's why that change was reverted.

With this change, it'd look like this instead:

```yaml
steps:
  - plugins:
      - ecr#v2.2.0:
          login: true
          account_ids: "$AWS_ACCOUNT_1_ID"
          assume_role:
            role_arn: "arn:aws:iam::$AWS_ACCOUNT_1_ID:role/$AWS_ROLE_1"
      - ecr#v2.2.0:
          login: true
          account_ids: "$AWS_ACCOUNT_2_ID"
          assume_role:
            role_arn: "arn:aws:iam::$AWS_ACCOUNT_2_ID:role/$AWS_ROLE_2"
```

I believe this would be a common enough use-case to justify including it within the plugin, but I'm happy to discuss that further.

Related: #33 