### PR TITLE
Ensure a log output heading is always shown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This will login docker to ECR prior to running your script.
 steps:
   - command: ./run_build.sh
     plugins:
-      - ecr#v2.1.1:
+      - ecr#v2.2.0:
           login: true
 ```
 
@@ -23,7 +23,7 @@ If you want to log in to ECR on [another account](https://docs.aws.amazon.com/Am
 steps:
   - command: ./run_build.sh
     plugins:
-      - ecr#v2.1.1:
+      - ecr#v2.2.0:
           login: true
           account_ids: "0015615400570"
           region: "ap-southeast-2"

--- a/hooks/environment
+++ b/hooks/environment
@@ -73,6 +73,8 @@ function retry() {
 # 'aws ecr get-login-password' was not available until v1.7.10 which
 # was only released earlier that same month.
 function login_using_aws_ecr_get_login() {
+  echo "~~~ Authenticating with AWS ECR :ecr: :docker:"
+
   # bash 3.x compatible equivalent of mapfile;
   # https://github.com/koalaman/shellcheck/wiki/SC2207
   registry_ids=()
@@ -107,10 +109,9 @@ function login_using_aws_ecr_get_login() {
   fi
 
   if [[ ${#registry_ids[@]} -gt 0 ]] ; then
-    echo "~~~ Authenticating with AWS ECR to ${registry_ids[*]}"
+    # amend the ~~~ log heading with ^^^ to add the AWS account IDs
+    echo "^^^ Authenticating with AWS ECR for ${registry_ids[*]} :ecr: :docker:"
     login_args+=("--registry-ids" "${registry_ids[@]}")
-  else
-    echo "~~~ Authenticating with AWS ECR"
   fi
 
   # shellcheck disable=SC2068
@@ -123,6 +124,7 @@ function login_using_aws_ecr_get_login() {
 }
 
 function login_using_aws_ecr_get_login_password() {
+  echo "~~~ Authenticating with AWS ECR :ecr: :docker:"
   local region="${BUILDKITE_PLUGIN_ECR_REGISTRY_REGION:-${BUILDKITE_PLUGIN_ECR_REGION:-${AWS_DEFAULT_REGION:-}}}"
   if [[ -z $region ]]; then
     region="us-east-1"
@@ -140,6 +142,8 @@ function login_using_aws_ecr_get_login_password() {
     echo >&2 "AWS account ID required via plugin config or 'aws sts get-caller-identity'"
     exit 1
   fi
+  # amend the ~~~ log heading with ^^^ to add the AWS account IDs
+  echo "^^^ Authenticating with AWS ECR in $region for ${account_ids[*]} :ecr: :docker:"
   local password; password="$(aws --region "$region" ecr get-login-password)"
   for account_id in "${account_ids[@]}"; do
     docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -21,6 +21,8 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD/hooks/environment"
 
   assert_success
+  assert_output --partial "~~~ Authenticating with AWS ECR :ecr: :docker:"
+  assert_output --partial "^^^ Authenticating with AWS ECR in ap-southeast-2 for 321321321321 :ecr: :docker:"
   assert_output --partial "logging in to docker"
   [[ $(cat /tmp/password-stdin) == "hunter2" ]]
 
@@ -197,6 +199,7 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD/hooks/environment"
 
   assert_success
+  assert_output --partial "~~~ Authenticating with AWS ECR :ecr: :docker:"
   assert_output --partial "logging in to docker"
 
   unstub aws
@@ -236,6 +239,8 @@ load '/usr/local/lib/bats/load.bash'
   run "$PWD/hooks/environment"
 
   assert_success
+  assert_output --partial "~~~ Authenticating with AWS ECR :ecr: :docker:"
+  assert_output --partial "^^^ Authenticating with AWS ECR for 1111 2222 :ecr: :docker:"
   assert_output --partial "logging in to docker"
 
   unstub aws


### PR DESCRIPTION
Otherwise the log output (and timing information) of this plugin is grouped into whatever previous heading existed.
For [elastic-stack](https://github.com/buildkite/elastic-ci-stack-for-aws) it ends up included under the S3 secrets heading.