### PR TITLE
Add retry to get-login-password

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -144,7 +144,7 @@ function login_using_aws_ecr_get_login_password() {
   fi
   # amend the ~~~ log heading with ^^^ to add the AWS account IDs
   echo "^^^ Authenticating with AWS ECR in $region for ${account_ids[*]} :ecr: :docker:"
-  local password; password="$(aws --region "$region" ecr get-login-password)"
+  local password; password="$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws --region "$region" ecr get-login-password)"
   for account_id in "${account_ids[@]}"; do
     docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
   done


### PR DESCRIPTION
The call to `get-login` (awscli pre 1.17.10) has retries, but the calls to `get-login-password` did not. This adds the retry functionality to systems that use the more up to date awscli. 

Please let me know if you'd like to see any more tests. I duplicated and modified existing tests to follow the retry testing pattern already present.

Any and all feedback is appreciated!
