### PR TITLE
Add retry when logging in to docker

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -146,7 +146,7 @@ function login_using_aws_ecr_get_login_password() {
   echo "^^^ Authenticating with AWS ECR in $region for ${account_ids[*]} :ecr: :docker:"
   local password; password="$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws --region "$region" ecr get-login-password)"
   for account_id in "${account_ids[@]}"; do
-    docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
+    retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
   done
 }
 


### PR DESCRIPTION
Error in buildkite:

![image](https://user-images.githubusercontent.com/1404443/118324538-0ae92b00-b4b7-11eb-8d07-e15d15c22a51.png)

I'm unsure whether the stdin redirection works or not in this case. Any suggestion?

Fixes #71 