### PR TITLE
docs: align example parameters with expected parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ steps:
     plugins:
       - ecr#v2.5.0:
           login: true
-          account_ids: "0015615400570"
+          account-ids: "0015615400570"
           region: "ap-southeast-2"
 ```
 
@@ -38,8 +38,8 @@ steps:
           login: true
           account-ids: "0015615400570"
           region: "ap-southeast-2"
-          assume_role:
-            role_arn: "arn:aws:iam::0015615400570:role/demo"
+          assume-role:
+            role-arn: "arn:aws:iam::0015615400570:role/demo"
 ```
 
 ## Options


### PR DESCRIPTION
Just noticed that the parameters in the usage examples were snake case instead of kebab. This should help people who don't read the manual like me :wink: 