### PR TITLE
Fix shebang to support NixOS

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu -o pipefail
 
 # Reads either a value or a list from plugin config


### PR DESCRIPTION
bash is not always in `/bin`; this allows the plugin to run on e.g. NixOS