### PR TITLE
Refer to ECR URLs using "https://"

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -155,7 +155,7 @@ function login_using_aws_ecr_get_login_password() {
   echo "^^^ Authenticating with AWS ECR in $region for ${account_ids[*]} :ecr: :docker:"
   local password; password="$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws --region "$region" ecr get-login-password)"
   for account_id in "${account_ids[@]}"; do
-    retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
+    retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin "https://$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
   done
 }
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -16,7 +16,7 @@ load '/usr/local/lib/bats/load.bash'
     "--region ap-southeast-2 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 321321321321.dkr.ecr.ap-southeast-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin https://321321321321.dkr.ecr.ap-southeast-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -40,7 +40,7 @@ load '/usr/local/lib/bats/load.bash'
     "--region ap-southeast-2 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 321321321321.dkr.ecr.ap-southeast-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin https://321321321321.dkr.ecr.ap-southeast-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -61,7 +61,7 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-west-2 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 421321321321.dkr.ecr.us-west-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin https://421321321321.dkr.ecr.us-west-2.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -81,7 +81,7 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-east-1 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 421321321321.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin https://421321321321.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
 
   run "$PWD/hooks/environment"
@@ -105,8 +105,8 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-east-1 ecr get-login-password : echo sameforeachaccount"
 
   stub docker \
-    "login --username AWS --password-stdin 111111111111.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-0 ; echo logging in to docker" \
-    "login --username AWS --password-stdin 222222222222.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-1 ; echo logging in to docker"
+    "login --username AWS --password-stdin https://111111111111.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-0 ; echo logging in to docker" \
+    "login --username AWS --password-stdin https://222222222222.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-1 ; echo logging in to docker"
 
 
   run "$PWD/hooks/environment"
@@ -129,8 +129,8 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-east-1 ecr get-login-password : echo sameforeachaccount"
 
   stub docker \
-    "login --username AWS --password-stdin 333333333333.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-0 ; echo logging in to docker" \
-    "login --username AWS --password-stdin 444444444444.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-1 ; echo logging in to docker"
+    "login --username AWS --password-stdin https://333333333333.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-0 ; echo logging in to docker" \
+    "login --username AWS --password-stdin https://444444444444.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin-1 ; echo logging in to docker"
 
 
   run "$PWD/hooks/environment"
@@ -153,7 +153,7 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-east-1 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 888888888888.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin https://888888888888.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -178,7 +178,7 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-east-1 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 888888888888.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin https://888888888888.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -203,8 +203,8 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-east-1 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 888888888888.dkr.ecr.us-east-1.amazonaws.com : exit 1" \
-    "login --username AWS --password-stdin 888888888888.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
+    "login --username AWS --password-stdin https://888888888888.dkr.ecr.us-east-1.amazonaws.com : exit 1" \
+    "login --username AWS --password-stdin https://888888888888.dkr.ecr.us-east-1.amazonaws.com : cat > /tmp/password-stdin ; echo logging in to docker"
 
   run "$PWD/hooks/environment"
 
@@ -250,8 +250,8 @@ load '/usr/local/lib/bats/load.bash'
     "--region us-east-1 ecr get-login-password : echo hunter2"
 
   stub docker \
-    "login --username AWS --password-stdin 888888888888.dkr.ecr.us-east-1.amazonaws.com : exit 1" \
-    "login --username AWS --password-stdin 888888888888.dkr.ecr.us-east-1.amazonaws.com : exit 1"
+    "login --username AWS --password-stdin https://888888888888.dkr.ecr.us-east-1.amazonaws.com : exit 1" \
+    "login --username AWS --password-stdin https://888888888888.dkr.ecr.us-east-1.amazonaws.com : exit 1"
 
   run "$PWD/hooks/environment"
 


### PR DESCRIPTION
This may be a docker bug, or may not be. When you have the [ECR
docker-credential helper](https://github.com/awslabs/amazon-ecr-credential-helper) configured for an account/region combo,
weirdly attempting a `docker login` to that same account/region will
result in an error[1].

However, if we simply prefix the ECR URL with `https`, this error goes
away[2]. I don't believe using this prefix causes any issues otherwise,
and is actually inline with the previous functionality of `v2.0.0` where
it was doing an `eval` of the string returned by `aws ecr get-login`,
which did refer to ECR URLs with that prefix.

Indeed doing an ECR login when you have a credential helper configured
is quite redundant, but we'd rather succeed and then have docker not use
the credentials anyway than fail the build completely due to docker
"failing to store the credentials".

[1]:
```
Error saving credentials: error storing credentials - err: exit status 1, out: `not implemented`
```

[2]:
```
WARNING! Your password will be stored unencrypted in /Users/danial.pearce/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```