### PR TITLE
Add support for assuming a role via OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ steps:
             role_arn: "arn:aws:iam::0015615400570:role/demo"
 ```
 
+It's also possible to assume a role using OIDC. This will call `buildkite-agent oidc request-token --audience sts.amazonaws.com`
+and exchange the resulting token for AWS credentials which are then used for the ECR login
+
+```yml
+steps:
+  - command: ./run_build.sh
+    plugins:
+      - ecr#v2.7.0:
+          login: true
+          account-ids: "0015615400570"
+          region: "ap-southeast-2"
+          assume_role:
+            role_arn: "arn:aws:iam::0015615400570:role/demo"
+            oidc: true
+```
+
 ## Options
 
 ### `login`
@@ -75,6 +91,10 @@ Retries login after a delay N times. Defaults to 0.
 > Updates AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN environment variables.
 
 Assume an AWS IAM role before ECR login. Supports `role-arn` and `duration-seconds` (optional) per the [associated AWS CLI command.](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/assume-role.html)
+
+By default the role is assumed using the AWS IAM `AssumeRole` process. It's
+also possible to assume the role using OIDC and the AWS IAM
+`AssumeRoleWithWebIdentity` process, by passing: `oidc: true`
 
 ### `profile` (optional)
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -187,6 +187,39 @@ function login() {
   fi
 }
 
+function assume_role_via_oidc_for_ecr_login() {
+  local export_credentials
+
+  echo "~~~ :buildkite::key::aws: Requesting an OIDC token for AWS from buildkite"
+
+  BUILDKITE_OIDC_TOKEN="$(buildkite-agent oidc request-token --audience sts.amazonaws.com)"
+
+  echo "~~~ :aws: Assuming role using OIDC token"
+
+  # This query creates an outer array, then multiple inner arrays of [key,value]
+  # pairs. Then it projects the outer array, and joins each inner array to form
+  # a key=value string. Printing the final array with --output text results in a
+  # string of the key=value pairs joined by space characters.
+  export_credentials="$(aws sts assume-role-with-web-identity \
+    --role-arn "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_ROLE_ARN}" \
+    --role-session-name "ecr-login-buildkite-plugin" \
+    --duration-seconds "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_DURATION_SECONDS:-3600}" \
+    --web-identity-token "${BUILDKITE_OIDC_TOKEN}" \
+    --output text \
+    --query "[['AWS_ACCESS_KEY_ID',Credentials.AccessKeyId],['AWS_SECRET_ACCESS_KEY',Credentials.SecretAccessKey],['AWS_SESSION_TOKEN',Credentials.SessionToken]][*].join(\`=\`,@)")"
+
+  #shellcheck disable=SC2181
+  if [[ $? -ne 0 ]]; then
+    echo "^^^ +++"
+    echo "Failed to assume AWS role:"
+    echo "${export_credentials}"
+    exit 1
+  fi
+
+  #shellcheck disable=SC2086
+  export ${export_credentials?}
+}
+
 function assume_role_for_ecr_login() {
   local export_credentials
 
@@ -208,7 +241,11 @@ function assume_role_for_ecr_login() {
 if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
   (
     if [[ -n "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_ROLE_ARN:-}" ]]; then
-      assume_role_for_ecr_login
+      if [[ -n "${BUILDKITE_PLUGIN_ECR_ASSUME_ROLE_OIDC:-}" ]]; then
+        assume_role_via_oidc_for_ecr_login
+      else
+        assume_role_for_ecr_login
+      fi
     fi
 
     login

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,6 +23,8 @@ configuration:
       properties:
         role-arn:
           type: string
+        oidc:
+          type: boolean
         duration-seconds:
           type: number
           default: 3600


### PR DESCRIPTION
An experiment in offering the option to assume a role via OIDC (AKA `AssumeRoleWithWebIdentity`) rather than `AssumeRole`.

This might be desirable in Buildkite setups where a shared pool of agents is running jobs for multiple teams, and assuming roles in accounts can be limited to particular pipelines rather than available to any job that can use the local EC2 Instance Role