### PR TITLE
DO NOT MERGE: Minimal repro for "trap breaks retry" problem

### DIFF
--- a/env-hook-repro.sh
+++ b/env-hook-repro.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+handle_err() {
+  echo "^^^ +++"
+  echo ":alert: Elastic CI Stack environment hook failed" >&2
+  exit 53
+}
+
+trap handle_err ERR
+
+export BUILDKITE_PLUGIN_ECR_RETRIES=3
+export BUILDKITE_PLUGIN_ECR_LOGIN=1
+
+trap - ERR
+source hooks/environment
+trap handle_err ERR
+

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+echo "Retries: ${BUILDKITE_PLUGIN_ECR_RETRIES:-0}"
+
 # Reads either a value or a list from plugin config
 function plugin_read_list() {
   local prefix="BUILDKITE_PLUGIN_ECR_$1"
@@ -60,13 +62,19 @@ function retry() {
     shift
   fi
 
+  echo "Trying ECR login with max ${max_attempts} attempts"
+
+  set -x
   while (( attempt_num <= max_attempts )); do
     set +e
+    # This is getting caught by the 'trap' command in the caller
     "$@" <<< "${stdin_value:-}"
     exit_code=$?
     set -e
 
     if [[ $retries -eq 0 ]] || [[ $exit_code -eq 0 ]]; then
+      echo "retries: $retries"
+      echo "exit_code: $exit_code"
       return $exit_code
     elif (( attempt_num == max_attempts )) ; then
       echo "Login failed after $attempt_num attempts" >&2
@@ -177,6 +185,11 @@ function login_using_aws_ecr_get_login_password() {
   done
 }
 
+function busted_login() {
+  retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" ./fail.sh
+
+}
+
 function login() {
   if aws_version_ge "1.17.10"; then
     # 'aws ecr get-login-password' was added in awscli 1.17.10
@@ -211,6 +224,6 @@ if [[ "${BUILDKITE_PLUGIN_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
       assume_role_for_ecr_login
     fi
 
-    login
+    busted_login
   )
 fi


### PR DESCRIPTION
* Creates a new function `busted_login`, which always fails
* Calls `busted_login` instead of `login` on execution
* Creates a repro script, `env-hook-repro.sh`, which simulates the behaviour of the Elastic Stack's agent `environment` hook (the real thing is [here](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/packer/linux/conf/buildkite-agent/hooks/environment))

Run the repro script to see how the `trap` command breaks the `retry` function defined in the `environment` hook.

We expect:

<details>
<summary>Expected execution log</summary>

```bash
$ ./env-hook-repro.sh
Retries: 3
Trying ECR login with max 4 attempts
+ ((  attempt_num <= max_attempts  ))
+ set +e
+ ./fail.sh
./hooks/environment: line 71: ./fail.sh: No such file or directory
+ exit_code=127
+ set -e
+ [[ 3 -eq 0 ]]
+ [[ 127 -eq 0 ]]
+ ((  attempt_num == max_attempts  ))
+ echo 'Login failed on attempt 1 of 4. Trying again in 1 seconds...'
Login failed on attempt 1 of 4. Trying again in 1 seconds...
+ sleep 1
+ ((  attempt_num <= max_attempts  ))
+ set +e
+ ./fail.sh
./hooks/environment: line 71: ./fail.sh: No such file or directory
+ exit_code=127
+ set -e
+ [[ 3 -eq 0 ]]
+ [[ 127 -eq 0 ]]
+ ((  attempt_num == max_attempts  ))
+ echo 'Login failed on attempt 2 of 4. Trying again in 2 seconds...'
Login failed on attempt 2 of 4. Trying again in 2 seconds...
+ sleep 2
+ ((  attempt_num <= max_attempts  ))
+ set +e
+ ./fail.sh
./hooks/environment: line 71: ./fail.sh: No such file or directory
+ exit_code=127
+ set -e
+ [[ 3 -eq 0 ]]
+ [[ 127 -eq 0 ]]
+ ((  attempt_num == max_attempts  ))
+ echo 'Login failed on attempt 3 of 4. Trying again in 3 seconds...'
Login failed on attempt 3 of 4. Trying again in 3 seconds...
+ sleep 3
+ ((  attempt_num <= max_attempts  ))
+ set +e
+ ./fail.sh
./hooks/environment: line 71: ./fail.sh: No such file or directory
+ exit_code=127
+ set -e
+ [[ 3 -eq 0 ]]
+ [[ 127 -eq 0 ]]
+ ((  attempt_num == max_attempts  ))
+ echo 'Login failed after 4 attempts'
Login failed after 4 attempts
+ return 127
^^^ +++
:alert: Elastic CI Stack environment hook failed

$ echo $?
53
```

</details>

We see:

<details>
<summary>Actual execution log</summary>

```bash
$ ./env-hook-repro.sh  
Retries: 3
Trying ECR login with max 4 attempts
++ ((  attempt_num <= max_attempts  ))
++ set +e
++ ./fail.sh
hooks/environment: line 71: ./fail.sh: No such file or directory
+++ handle_err
+++ echo '^^^ +++'
^^^ +++
+++ echo ':alert: Elastic CI Stack environment hook failed'
:alert: Elastic CI Stack environment hook failed
+++ exit 53
^^^ +++
:alert: Elastic CI Stack environment hook failed
$ echo $?
53
```

</details>