### PR TITLE
Add support for authenticating to a China ECR

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -201,7 +201,7 @@ function login_using_aws_ecr_get_login_password() {
   echo "^^^ Authenticating with AWS ECR in $region for ${account_ids[*]} :ecr: :docker:"
 
   local ecr_registry_url;
-  if [[ $(region:0:3) == "cn-" ]]; then
+  if [[ ${region:0:3} == "cn-" ]]; then
     # the ecr registry in China regions has a different URL
     ecr_registry_url="$account_id.dkr.ecr.$region.amazonaws.com.cn"
   else

--- a/hooks/environment
+++ b/hooks/environment
@@ -200,6 +200,14 @@ function login_using_aws_ecr_get_login_password() {
   # amend the ~~~ log heading with ^^^ to add the AWS account IDs
   echo "^^^ Authenticating with AWS ECR in $region for ${account_ids[*]} :ecr: :docker:"
 
+  local ecr_registry_url;
+  if [[ $(region:0:3) == "cn-" ]]; then
+    # the ecr registry in China regions has a different URL
+    ecr_registry_url="$account_id.dkr.ecr.$region.amazonaws.com.cn"
+  else
+    ecr_registry_url="$account_id.dkr.ecr.$region.amazonaws.com"
+  fi
+
   local password;
   local public_password;
   for account_id in "${account_ids[@]}"; do
@@ -211,7 +219,7 @@ function login_using_aws_ecr_get_login_password() {
     else
       # it is only necessary to get the password once
       password=${password:-"$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws ${login_args[@]+"${login_args[@]}"} ecr get-login-password)"}
-      retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin "$account_id.dkr.ecr.$region.amazonaws.com" <<< "$password"
+      retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin "$ecr_registry_url" <<< "$password" 
     fi
   done
 }

--- a/hooks/environment
+++ b/hooks/environment
@@ -200,14 +200,6 @@ function login_using_aws_ecr_get_login_password() {
   # amend the ~~~ log heading with ^^^ to add the AWS account IDs
   echo "^^^ Authenticating with AWS ECR in $region for ${account_ids[*]} :ecr: :docker:"
 
-  local ecr_registry_url;
-  if [[ ${region:0:3} == "cn-" ]]; then
-    # the ecr registry in China regions has a different URL
-    ecr_registry_url="$account_id.dkr.ecr.$region.amazonaws.com.cn"
-  else
-    ecr_registry_url="$account_id.dkr.ecr.$region.amazonaws.com"
-  fi
-
   local password;
   local public_password;
   for account_id in "${account_ids[@]}"; do
@@ -217,6 +209,12 @@ function login_using_aws_ecr_get_login_password() {
       public_password="$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws --region us-east-1 ecr-public get-login-password)"
       retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin public.ecr.aws <<< "$public_password"
     else
+      if [[ ${region:0:3} == "cn-" ]]; then
+        # the ecr registry in China regions has a different URL
+        ecr_registry_url="$account_id.dkr.ecr.$region.amazonaws.com.cn"
+      else
+        ecr_registry_url="$account_id.dkr.ecr.$region.amazonaws.com"
+      fi
       # it is only necessary to get the password once
       password=${password:-"$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws ${login_args[@]+"${login_args[@]}"} ecr get-login-password)"}
       retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin "$ecr_registry_url" <<< "$password"

--- a/hooks/environment
+++ b/hooks/environment
@@ -219,7 +219,7 @@ function login_using_aws_ecr_get_login_password() {
     else
       # it is only necessary to get the password once
       password=${password:-"$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws ${login_args[@]+"${login_args[@]}"} ecr get-login-password)"}
-      retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin "$ecr_registry_url" <<< "$password" 
+      retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin "$ecr_registry_url" <<< "$password"
     fi
   done
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -155,7 +155,7 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   rm /tmp/password-stdin
 }
 
-@test "ECR login; configured account ID, configured region" {
+@test "ECR login; configured account ID, configured China region" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=321321321321
   export BUILDKITE_PLUGIN_ECR_REGION=cn-north-1

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -129,6 +129,57 @@ load "${BATS_PLUGIN_PATH}/load.bash"
   rm /tmp/password-stdin
 }
 
+@test "ECR login; configured account ID, configured China region, configured profile" {
+  export BUILDKITE_PLUGIN_ECR_LOGIN=true
+  export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=321321321321
+  export BUILDKITE_PLUGIN_ECR_REGION=cn-north-1
+  export BUILDKITE_PLUGIN_ECR_PROFILE=ecr
+
+  stub aws \
+    "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
+    "--region cn-north-1 --profile ecr ecr get-login-password : echo hunter2"
+
+  stub docker \
+    "login --username AWS --password-stdin 321321321321.dkr.ecr.cn-north-1.amazonaws.com.cn : cat > /tmp/password-stdin ; echo logging in to docker"
+
+  run "$PWD/hooks/environment"
+
+  assert_success
+  assert_output --partial "~~~ Authenticating with AWS ECR :ecr: :docker:"
+  assert_output --partial "^^^ Authenticating with AWS ECR in cn-north-1 for 321321321321 :ecr: :docker:"
+  assert_output --partial "logging in to docker"
+  assert_equal "hunter2" "$(cat /tmp/password-stdin)"
+
+  unstub aws
+  unstub docker
+  rm /tmp/password-stdin
+}
+
+@test "ECR login; configured account ID, configured region" {
+  export BUILDKITE_PLUGIN_ECR_LOGIN=true
+  export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS=321321321321
+  export BUILDKITE_PLUGIN_ECR_REGION=cn-north-1
+
+  stub aws \
+    "--version : echo aws-cli/2.0.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3" \
+    "--region cn-north-1 ecr get-login-password : echo hunter2"
+
+  stub docker \
+    "login --username AWS --password-stdin 321321321321.dkr.ecr.cn-north-1.amazonaws.com.cn : cat > /tmp/password-stdin ; echo logging in to docker"
+
+  run "$PWD/hooks/environment"
+
+  assert_success
+  assert_output --partial "~~~ Authenticating with AWS ECR :ecr: :docker:"
+  assert_output --partial "^^^ Authenticating with AWS ECR in cn-north-1 for 321321321321 :ecr: :docker:"
+  assert_output --partial "logging in to docker"
+  assert_equal "hunter2" "$(cat /tmp/password-stdin)"
+
+  unstub aws
+  unstub docker
+  rm /tmp/password-stdin
+}
+
 @test "ECR login; multiple account IDs" {
   export BUILDKITE_PLUGIN_ECR_LOGIN=true
   export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0=111111111111


### PR DESCRIPTION
## Context

China based ECR registries are not currently supported by this plugin as they do not use the standard `account_id.dkr.ecr.$region.amazonaws.com` domain. They instead use the `account_id.dkr.ecr.$region.amazonaws.com.cn`.

This results in the plugin failing to authenticate for accounts in the China partition.

## Intent
* Add support for authenticating to regions in the China partition by changing to the China URL when the region begins with `cn-`.
* Add supporting tests (not at all familiar with your test platform, so please check the tests are appropriate).

## Notes

* Documentation showing the different domain is available here: https://docs.amazonaws.cn/en_us/AmazonECR/latest/userguide/Registries.html
* I suspect there could be a similar issue with other partitions such as GOV partitions, but I don't have access to such a partition to check