### PR TITLE
Fix AWS CLI version parsing

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -33,9 +33,25 @@ function plugin_read_list() {
 }
 
 # Check a provided aws-cli version is greater or equal than the current
+# Search for SemVer in the string, handling directory paths in AWS CLI output
+# This will also account for any potential symlinks/virtual environments
 function aws_version_ge() {
-  local current; current="$(aws --version 2>&1 | awk -F'[/ ]' '{print $2}')"
+  local aws_output; aws_output="$(aws --version 2>&1 | head -n1)"
+  # Match SemVer x.x.x format anywhere after aws-cli/, skipping non-numeric prefixes like "workspace/" that we've seen in a bug report
+  local current; current="$(echo "$aws_output" | sed -n 's/^aws-cli\/[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
   local wanted="$1"
+
+  # If we couldn't parse the version with the robust method, then we'll try the old method as fallback (although, we should never get here... but just in case)
+  if [[ -z "$current" ]]; then
+    current="$(echo "$aws_output" | awk -F'[/ ]' '{print $2}')"
+  fi
+
+  # Throw verbose output if version parsing fails so we can debug more accurately
+  if [[ -z "$current" ]]; then
+    echo "Could not parse AWS CLI version from output: $aws_output" >&2
+    return 1
+  fi
+
   version_a_gte_b "$current" "$wanted"
 }
 
@@ -204,7 +220,7 @@ function login_using_aws_ecr_get_login_password() {
   local public_password;
   for account_id in "${account_ids[@]}"; do
     if [[ $account_id == "public.ecr.aws" ]]; then
-      # special AWS command with us-east-1 region 
+      # special AWS command with us-east-1 region
       echo "Ignoring region for $account_id and forcing us-east-1"
       public_password="$(retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" aws --region us-east-1 ecr-public get-login-password)"
       retry "${BUILDKITE_PLUGIN_ECR_RETRIES:-0}" --with-stdin docker login --username AWS --password-stdin public.ecr.aws <<< "$public_password"

--- a/hooks/environment
+++ b/hooks/environment
@@ -36,6 +36,12 @@ function plugin_read_list() {
 # Search for SemVer in the string, handling directory paths in AWS CLI output
 # This will also account for any potential symlinks/virtual environments
 function aws_version_ge() {
+
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "Error: AWS CLI is not installed or not in PATH" >&2
+    return 1
+  fi
+
   local aws_output; aws_output="$(aws --version 2>&1 | head -n1)"
   # Match SemVer x.x.x format anywhere after aws-cli/, skipping non-numeric prefixes like "workspace/" that we've seen in a bug report
   local current; current="$(echo "$aws_output" | sed -n 's/^aws-cli\/[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -84,3 +84,10 @@ load "$PWD/hooks/environment"
   assert_success
   unset -f aws
 }
+
+@test "aws_version_ge: fails when AWS CLI is not installed" {
+  export PATH="/bin:/usr/bin"
+  run aws_version_ge "1.0.0"
+  assert_failure
+  assert_output --partial "Error: AWS CLI is not installed or not in PATH"
+}

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -44,3 +44,43 @@ load "$PWD/hooks/environment"
   run version_a_gte_b "2.0.2" "2.0.0"
   assert_success
 }
+
+@test "aws_version_ge: standard format aws-cli/2.9.0" {
+  aws() { echo "aws-cli/2.9.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3"; }
+  export -f aws
+  run aws_version_ge "2.8.0"
+  assert_success
+  unset -f aws
+}
+
+@test "aws_version_ge: workspace format aws-cli/workspace/2.9.0" {
+  aws() { echo "aws-cli/workspace/2.9.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3"; }
+  export -f aws
+  run aws_version_ge "2.8.0"
+  assert_success
+  unset -f aws
+}
+
+@test "aws_version_ge: complex path aws-cli/workspace/build/2.9.0" {
+  aws() { echo "aws-cli/workspace/build/2.9.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3"; }
+  export -f aws
+  run aws_version_ge "2.8.0"
+  assert_success
+  unset -f aws
+}
+
+@test "aws_version_ge: version check fails when current < wanted" {
+  aws() { echo "aws-cli/workspace/1.18.0 Python/3.8.1 Linux/5.5.6-arch1-1 botocore/1.15.3"; }
+  export -f aws
+  run aws_version_ge "2.0.0"
+  assert_failure
+  unset -f aws
+}
+
+@test "aws_version_ge: handles multiple semver patterns correctly" {
+  aws() { echo "aws-cli/2.27.50 Python/3.13.5 Darwin/25.0.0 source/arm64"; }
+  export -f aws
+  run aws_version_ge "2.20.0"
+  assert_success
+  unset -f aws
+}


### PR DESCRIPTION
We've had a report of a bug where `workspace` was the returned part of the string at `$2` from the sub-command of `current="$(aws --version 2>&1 | awk -F'[/ ]' '{print $2}')"`

This introduces fragility when the string is not exactly as anticipated, as such, we've expanded on this to specifically look for SemVer in the section of the string beginning with `aws-cli/`, ignoring whitespaces to avoid getting the version of Python, for example.

Adds check to ensure aws cli is installed.

Added some bats tests to validate the behavior.